### PR TITLE
fix pip to pip3

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Join the conversation in the [Messages Slack Team](https://messages-py.herokuapp
 ## Installation
 
 ```console
-$ pip install messages
+$ pip3 install messages
 ```
 
 ## Supported Messages


### PR DESCRIPTION
@trp07 
pip will create a soft link to pip3 for people who only have python3 installed. IN this case it doesn't matter if pip or pip3 are used.
But for those who have both Py2 and Py3 installed it could be an issue if they use pip install vs pip3 install. 
They may want to install packages for Py 3, but if they use pip install, they will install for Py 2. 
It's small fix and can save trouble. SImilar for installation guide in Wiki.