### PR TITLE
Add 'verbose' flag to sending email.

### DIFF
--- a/messages/_utils.py
+++ b/messages/_utils.py
@@ -1,5 +1,6 @@
 """Utility Module - functions useful to other modules."""
 
+import datetime
 import validus
 
 from ._exceptions import InvalidMessageInputError
@@ -75,3 +76,8 @@ def validate_telegrambot(msg, attr):
     """TelegramBot input validator function."""
     if attr in ('chat_id'):
         check_valid(msg, attr, validus.isint, 'integer as a string')
+
+
+def timestamp():
+    """Get current date and time."""
+    return '{:%Y-%b-%d %H:%M:%S}'.format(datetime.datetime.now())

--- a/messages/cli.py
+++ b/messages/cli.py
@@ -94,6 +94,8 @@ def list_types():
     help='List available message types and exit.')
 @option('-C', '--configure', is_flag=True,
     help='Configure specified message type and exit.')
+@option('-V', '--verbose', is_flag=True,
+    help='Display debug information.')
 @click.version_option(version=VERSION, prog_name='Messages')
 @click.pass_context
 def main(ctx, **kwds):
@@ -129,4 +131,3 @@ def main(ctx, **kwds):
         list_types()
         click.echo('Try `messages --help` for more information')
         sys.exit(0)
-

--- a/messages/email_.py
+++ b/messages/email_.py
@@ -89,14 +89,22 @@ class Email(Message):
         """print(Email(**args)) method.
            Indentation value can be overridden in the function call.
            The default is new line"""
-        return(f'{identation}Server: {self.server}:{self.port}'
-               f'{identation}From: {self.from_}'
-               f'{identation}To: {self.to}'
-               f'{identation}Cc: {self.cc}'
-               f'{identation}Bcc: {self.bcc}'
-               f'{identation}Subject: {self.subject}'
-               f'{identation}body: {self.body[0:40]}...'
-               f'{identation}attachments: {self.attachments}')
+        return('{}Server: {}:{}'
+               '{}From: {}'
+               '{}To: {}'
+               '{}Cc: {}'
+               '{}Bcc: {}'
+               '{}Subject: {}'
+               '{}body: {}...'
+               '{}attachments: {}'
+               .format(identation, self.server, self.port,
+                       identation, self.from_,
+                       identation, self.to,
+                       identation, self.cc,
+                       identation, self.bcc,
+                       identation, self.subject,
+                       identation, self.body[0:40],
+                       identation, self.attachments))
 
 
     @staticmethod

--- a/messages/email_.py
+++ b/messages/email_.py
@@ -202,9 +202,9 @@ class Email(Message):
 
         self.generate_email()
         if self.verbose:
-            print(f"""Debugging info
-                  \r---------------
-                  \r{timestamp()} Message created.""")
+            print('Debugging info'
+                  '\n--------------'
+                  '\n{} Message created.'.format(timestamp()))
 
         session = self.get_session()
         if self.verbose:

--- a/messages/email_.py
+++ b/messages/email_.py
@@ -66,7 +66,7 @@ class Email(Message):
     def __init__(
         self, from_=None, to=None, server=None, port=None,
         password=None, cc=None, bcc=None, subject='', body='',
-        attachments=None, profile=None, save=False
+        attachments=None, profile=None, save=False, verbose=False
     ):
 
         config_kwargs = {'from_': from_,
@@ -82,22 +82,21 @@ class Email(Message):
         self.body = body
         self.attachments = attachments or []
         self.message = None
+        self.verbose = verbose
 
 
-    def __str__(self):
-        """print(Email(**args)) method."""
-        return('MIMEMultipart Email:'
-               '\n\tServer: {}:{}'
-               '\n\tFrom: {}'
-               '\n\tTo: {}'
-               '\n\tCc: {}'
-               '\n\tBcc: {}'
-               '\n\tSubject: {}'
-               '\n\tbody: {}...'
-               '\n\tattachments: {}'
-               .format(self.server, self.port, self.from_, self.to,
-                       self.cc, self.bcc, self.subject, self.body[0:40],
-                       self.attachments))
+    def __str__(self, identation='\n'):
+        """print(Email(**args)) method.
+           Indentation value can be overridden in the function call.
+           The default is new line"""
+        return(f'{identation}Server: {self.server}:{self.port}'
+               f'{identation}From: {self.from_}'
+               f'{identation}To: {self.to}'
+               f'{identation}Cc: {self.cc}'
+               f'{identation}Bcc: {self.bcc}'
+               f'{identation}Subject: {self.subject}'
+               f'{identation}body: {self.body[0:40]}...'
+               f'{identation}attachments: {self.attachments}')
 
 
     @staticmethod
@@ -191,8 +190,17 @@ class Email(Message):
 
     def send(self):
         """Send the message."""
+        from ._utils import timestamp
+
         self.generate_email()
+        if self.verbose:
+            print(f"""Debugging info
+                  \r---------------
+                  \r{timestamp()} Message created.""")
+
         session = self.get_session()
+        if self.verbose:
+            print(timestamp(), 'Login successful.')
 
         recipients = []
         if self.to:
@@ -207,7 +215,13 @@ class Email(Message):
 
         session.sendmail(self.from_, recipients, self.message.as_string())
         session.quit()
-        print('Message sent...', file=sys.stdout)
+        if self.verbose:
+            print(timestamp(), 'Logged out.')
+
+        if self.verbose:
+            print(timestamp(), 'Email info:', self.__str__(identation='\n * '))
+
+        print('Message sent.')
 
 
     def send_async(self):


### PR DESCRIPTION
@trp07 
Added 'verbose' flag. 
Pls give feedback or requests for change (inline in PR) if needed.
In tests for --verbose I could create a new fixture with verbose attribute in Email class instance. INstead I've opted to add verbose flag in the tests as `e.verbose = True` (and False). Think this should do it, but lmk if better idea.
I've reorganized __str__ function with newer formatting using f'' notation and customizable indentation.
I've only added three tests to test_email.py file. I think we need more for CLI.
Cheers